### PR TITLE
Add PLD_GENERIC_HEADER.Length

### DIFF
--- a/source/payload-interfaces/index.rst
+++ b/source/payload-interfaces/index.rst
@@ -159,10 +159,31 @@ The HOB data starts with a common header defined as below::
   
   typedef struct {
     UINT8                Revision;
-    UINT8                Reserved[3];
+    UINT8                Reserved;
+    UINT16               Length;
   } PLD_GENERIC_HEADER;
 
   #pragma pack()
+
+``Revision``
+
+It doesn't increase when new members are appended to the end of the interface.
+
+It increases by one when existing members are renamed or re-interpreted for different purposes.
+
+``Length``
+
+The Length equals to the sizeof (PLD_GENERIC_HEADER) + sizeof (<additional members>).
+
+Consumers of the interfaces should only access those members that are covered by Length.
+
+.. note::
+  ``EFI_HOB_GUID_TYPE`` contains a Length field to tell the actual bytes the whole HOB data occupies.
+
+  It also includes the optional padding bytes to make sure each HOB is multiple of 8 bytes in length.
+
+  ``PLD_GENERIC_HEADER.Length`` tells the exact length of the meaningful data excluding the padding bytes.
+  So, it's always true that ``PLD_GENERIC_HEADER.Length`` is less than or equal to the Length in ``EFI_HOB_GUID_TYPE``.
 
 HOB data for different interfaces is defined in following sections.
 
@@ -195,6 +216,8 @@ The bootloader should pass ACPI table the payload. So that the payload could get
 ``PldHeader``
 
 PldHeader.Revision is 1.
+
+PldHeader.Length is 12.
 
 ``Rsdp``
 
@@ -232,6 +255,8 @@ The bootloader might pass SMBIOS table to the payload. So that the payload could
 
 PldHeader.Revision is 1.
 
+PldHeader.Length is 12.
+
 ``SmBiosEntryPoint``
 
 Points to the SMBIOS table in SMBIOS 3.0+ format if GUID is ``gPldSmbios3TableGuid``.
@@ -267,6 +292,8 @@ The bootloader might pass Device Tree to the payload. So that the payload could 
 ``PldHeader``
 
 PldHeader.Revision is 1.
+
+PldHeader.Length is 12.
 
 ``DeviceTreeAddress``
 
@@ -308,6 +335,8 @@ to payload.
 ``PldHeader``
 
 PldHeader.Revision is 1.
+
+PldHeader.Length is 18.
 
 ``UseMmio``
 

--- a/source/revision-history.rst
+++ b/source/revision-history.rst
@@ -4,7 +4,7 @@ Revision History
 ========  =================================================  ======
 Revision  Description                                        Date
 ========  =================================================  ======
-0.75      - Changed payload image format to ELF.             April 28, 2021
+0.75      - Changed payload image format to ELF.             May 11, 2021
           - Updated ACPI table requirement.
           - Separate new interfaces to a new chapter.
           - Reuse CPU HOB from PI Spec.
@@ -12,5 +12,6 @@ Revision  Description                                        Date
             information.
           - Add PLD_GENERIC_HEADER as the common header for
             new interfaces.
+          - Add PLD_GENERIC_HEADER.Length.
 0.7       Initial draft.                                     Sep 19, 2020
 ========  =================================================  ======


### PR DESCRIPTION
Old common header only contains Revision field.
Every time when the interface is changed, Revision increases.
But Revision cannot tell whether the change is to append new members
in the end of the interface, or change existing members.

This causes the Consumer (payload) hard to write code to consume
the interfaces. Because payload needs to define different structures
for different revisions of the same interface.

Having the Length in header can avoid payload defining new structures
when only new members are appended.

Supposing PLD_INTERFACE_A is changed for 3 times:

Initial:
  typedef struct {
    PLD_GENERIC_HEADER PldHeader;
    UINT8 a;
  } PLD_INTERFACE_A;
  // Revision = 1
  // Length   = 5

Add new member x:
  typedef struct {
    PLD_GENERIC_HEADER PldHeader;
    UINT8 a;
    UINT8 x;
  } PLD_INTERFACE_A;
  // Revision = 1 (no change for members appending)
  // Length   = 6

Change member x to y:
  typedef struct {
    PLD_GENERIC_HEADER PldHeader;
    UINT8 a;
    UINT8 y;
  } PLD_INTERFACE_A;
  // Revision = 2 (increase Revision)
  // Length   = 6

The InterfaceA.h can contain following:
  ------
  typedef struct {
    PLD_GENERIC_HEADER PldHeader;
    UINT8 a;
    UINT8 x;
  } PLD_INTERFACE_A;
  #define PLD_INTERFACE_A_REVISION 1

  typedef struct {
    PLD_GENERIC_HEADER PldHeader;
    UINT8 a;
    UINT8 y;
  } PLD_INTERFACE_A2;
  #define PLD_INTERFACE_A2_REVISION 2
  ------

The payload can write code as below:
---BEGIN---
if (Hdr->Revision == PLD_INTERFACE_A_REVISION) {
  PLD_INTERFACE_A *a = (PLD_INTERFACE_A *) Hdr;
  if (Hdr->Length >= OFFSET_OF (PLD_INTERFACE_A, x) + sizeof (UINT8)){
    // Access PLD_INTERFACE_A->x
  }
} else if (Hdr->Revision == PLD_INTERFACE_A2_REVISION) {
  PLD_INTERFACE_A2 *a = (PLD_INTERFACE_A2 *) Hdr;
  if (Hdr->Length >= OFFSET_OF (PLD_INTERFACE_A2, y) + sizeof (UINT8)){
    // Access PLD_INTERFACE_A2->y
  }
}
---END---

With Length field added, if only new members are appended,
the payload(consumer) code will be very easy to develop.

Signed-off-by: Ray Ni <ray.ni@intel.com>